### PR TITLE
fix prelu onnxruntime run bug

### DIFF
--- a/examples/oneflow2onnx/models/_test_ir_resnet50.py
+++ b/examples/oneflow2onnx/models/_test_ir_resnet50.py
@@ -1,0 +1,253 @@
+import oneflow as flow
+import oneflow.nn as nn
+from typing import Type, Any, Callable, Union, List, Optional
+from oneflow_onnx.oneflow2onnx.util import convert_to_onnx_and_check
+import tempfile
+
+
+def conv3x3(
+    in_planes: int, out_planes: int, stride: int = 1, groups: int = 1, dilation: int = 1
+) -> nn.Conv2d:
+    """3x3 convolution with padding"""
+    return nn.Conv2d(
+        in_planes,
+        out_planes,
+        kernel_size=3,
+        stride=stride,
+        padding=dilation,
+        groups=groups,
+        bias=False,
+        dilation=dilation,
+    )
+
+
+def conv1x1(in_planes: int, out_planes: int, stride: int = 1) -> nn.Conv2d:
+    """1x1 convolution"""
+    return nn.Conv2d(in_planes, out_planes, kernel_size=1, stride=stride, bias=False)
+
+
+class IBasicBlock(nn.Module):
+    expansion = 1
+
+    def __init__(
+        self,
+        inplanes,
+        planes,
+        stride=1,
+        downsample=None,
+        groups=1,
+        base_width=64,
+        dilation=1,
+    ):
+        super(IBasicBlock, self).__init__()
+        if groups != 1 or base_width != 64:
+            raise ValueError(
+                "BasicBlock only supports groups=1 and base_width=64")
+        if dilation > 1:
+            raise NotImplementedError(
+                "Dilation > 1 not supported in BasicBlock")
+        self.bn1 = nn.BatchNorm2d(inplanes, eps=1e-05,)
+        self.conv1 = conv3x3(inplanes, planes)
+        self.bn2 = nn.BatchNorm2d(planes, eps=1e-05,)
+        self.prelu = nn.PReLU(planes)
+        self.conv2 = conv3x3(planes, planes, stride)
+        self.bn3 = nn.BatchNorm2d(planes, eps=1e-05,)
+        self.downsample = downsample
+        self.stride = stride
+
+    def forward(self, x):
+        identity = x
+        out = self.bn1(x)
+        out = self.conv1(out)
+        out = self.bn2(out)
+        out = self.prelu(out)
+        out = self.conv2(out)
+        out = self.bn3(out)
+        if self.downsample is not None:
+            identity = self.downsample(x)
+        out += identity
+        return out
+
+
+class IResNet(nn.Module):
+    fc_scale = 7 * 7
+
+    def __init__(
+        self,
+        block,
+        layers,
+        dropout=0,
+        num_features=512,
+        zero_init_residual=False,
+        groups=1,
+        width_per_group=64,
+        replace_stride_with_dilation=None,
+        fp16=False,
+    ):
+        super(IResNet, self).__init__()
+        self.fp16 = fp16
+        self.inplanes = 64
+        self.dilation = 1
+        if replace_stride_with_dilation is None:
+            replace_stride_with_dilation = [False, False, False]
+        if len(replace_stride_with_dilation) != 3:
+            raise ValueError(
+                "replace_stride_with_dilation should be None "
+                "or a 3-element tuple, got {}".format(
+                    replace_stride_with_dilation)
+            )
+        self.groups = groups
+        self.base_width = width_per_group
+        self.conv1 = nn.Conv2d(
+            3, self.inplanes, kernel_size=3, stride=1, padding=1, bias=False
+        )
+        self.bn1 = nn.BatchNorm2d(self.inplanes, eps=1e-05)
+        self.prelu = nn.PReLU(self.inplanes)
+        self.layer1 = self._make_layer(block, 64, layers[0], stride=2)
+        self.layer2 = self._make_layer(
+            block, 128, layers[1], stride=2, dilate=replace_stride_with_dilation[0]
+        )
+        self.layer3 = self._make_layer(
+            block, 256, layers[2], stride=2, dilate=replace_stride_with_dilation[1]
+        )
+        self.layer4 = self._make_layer(
+            block, 512, layers[3], stride=2, dilate=replace_stride_with_dilation[2]
+        )
+        self.bn2 = nn.BatchNorm2d(512 * block.expansion, eps=1e-05,)
+        self.dropout = nn.Dropout(p=dropout, inplace=True)
+        self.fc = nn.Linear(512 * block.expansion *
+                            self.fc_scale, num_features)
+        self.features = nn.BatchNorm1d(num_features, eps=1e-05)
+        nn.init.constant_(self.features.weight, 1.0)
+        self.features.weight.requires_grad = False
+
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.normal_(m.weight, 0, 0.1)
+            elif isinstance(m, (nn.BatchNorm2d, nn.GroupNorm)):
+                nn.init.constant_(m.weight, 1)
+                nn.init.constant_(m.bias, 0)
+
+        if zero_init_residual:
+            for m in self.modules():
+                if isinstance(m, IBasicBlock):
+                    nn.init.constant_(m.bn2.weight, 0)
+
+    def _make_layer(self, block, planes, blocks, stride=1, dilate=False):
+        downsample = None
+        previous_dilation = self.dilation
+        if dilate:
+            self.dilation *= stride
+            stride = 1
+        if stride != 1 or self.inplanes != planes * block.expansion:
+            downsample = nn.Sequential(
+                conv1x1(self.inplanes, planes * block.expansion, stride),
+                nn.BatchNorm2d(planes * block.expansion, eps=1e-05,),
+            )
+        layers = []
+        layers.append(
+            block(
+                self.inplanes,
+                planes,
+                stride,
+                downsample,
+                self.groups,
+                self.base_width,
+                previous_dilation,
+            )
+        )
+        self.inplanes = planes * block.expansion
+        for _ in range(1, blocks):
+            layers.append(
+                block(
+                    self.inplanes,
+                    planes,
+                    groups=self.groups,
+                    base_width=self.base_width,
+                    dilation=self.dilation,
+                )
+            )
+
+        return nn.Sequential(*layers)
+
+    def forward(self, x):
+
+        x = self.conv1(x)
+        x = self.bn1(x)
+        x = self.prelu(x)
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.layer3(x)
+        x = self.layer4(x)
+        x = self.bn2(x)
+        x = flow.flatten(x, 1)
+        x = self.dropout(x)
+        x = self.fc(x)
+        x = self.features(x)
+
+        return x
+
+
+def _iresnet(arch, block, layers, pretrained, progress, **kwargs):
+    model = IResNet(block, layers, **kwargs)
+    if pretrained:
+        raise ValueError()
+    return model
+
+
+def iresnet18(pretrained=False, progress=True, **kwargs):
+    return _iresnet(
+        "iresnet18", IBasicBlock, [2, 2, 2, 2], pretrained, progress, **kwargs
+    )
+
+
+def iresnet34(pretrained=False, progress=True, **kwargs):
+    return _iresnet(
+        "iresnet34", IBasicBlock, [3, 4, 6, 3], pretrained, progress, **kwargs
+    )
+
+
+def iresnet50(pretrained=False, progress=True, **kwargs):
+    return _iresnet(
+        "iresnet50", IBasicBlock, [3, 4, 14, 3], pretrained, progress, **kwargs
+    )
+
+
+def iresnet100(pretrained=False, progress=True, **kwargs):
+    return _iresnet(
+        "iresnet100", IBasicBlock, [3, 13, 30, 3], pretrained, progress, **kwargs
+    )
+
+
+def iresnet200(pretrained=False, progress=True, **kwargs):
+    return _iresnet(
+        "iresnet200", IBasicBlock, [6, 26, 60, 6], pretrained, progress, **kwargs
+    )
+
+
+class ModelGraph(flow.nn.Graph):
+    def __init__(self, model):
+        super().__init__()
+        self.backbone = model
+
+    def build(self, x):
+        x = x.to("cuda")
+        out = self.backbone(x)
+        return out
+
+
+def test_resnet50():
+
+    model_module = iresnet50(dropout=0.0, num_features=512).to("cuda")
+    model_module.eval()
+    print(model_module)
+    model_graph = ModelGraph(model_module)
+    model_graph._compile(flow.randn(1, 3, 112, 112).to("cuda"))
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        flow.save(model_module.state_dict(), tmpdirname)
+        convert_to_onnx_and_check(
+            model_graph, flow_weight_dir=tmpdirname, onnx_model_path="/tmp", print_outlier=True)
+
+if __name__ == "__main__":
+    test_resnet50()

--- a/oneflow_onnx/oneflow2onnx/handlers/math.py
+++ b/oneflow_onnx/oneflow2onnx/handlers/math.py
@@ -92,11 +92,24 @@ class BiasAdd(common.BroadcastOp):
 
 
 @flow_op(["leaky_relu", "softplus"], onnx_op=["LeakyRelu", "Softplus"])
-@flow_op("prelu", onnx_op="PRelu", flow_ibns=["x", "alpha"])
 class DirectOpSinceOpset1:
     @classmethod
     def Version_1(cls, ctx, node, **kwargs):
         pass
+
+
+@flow_op("prelu", onnx_op="PRelu", flow_ibns=["x", "alpha"])
+class PreLUOp:
+    @classmethod
+    def Version_1(cls, ctx, node, **kwargs):
+        input_shape = ctx.get_shape(node.input_tensor_names[0])
+        alpha_shape = ctx.get_shape(node.input_tensor_names[1])
+        if len(alpha_shape) == 1:
+            new_shape = []
+            new_shape.append(alpha_shape[0])
+            for _ in range(1, len(input_shape) - 1):
+                new_shape.append(1)
+            ctx.set_shape(node.input_tensor_names[1], new_shape)
 
 
 @flow_op(

--- a/oneflow_onnx/oneflow2onnx/handlers/math.py
+++ b/oneflow_onnx/oneflow2onnx/handlers/math.py
@@ -99,7 +99,7 @@ class DirectOpSinceOpset1:
 
 
 @flow_op("prelu", onnx_op="PRelu", flow_ibns=["x", "alpha"])
-class PreLUOp:
+class PReLUOp:
     @classmethod
     def Version_1(cls, ctx, node, **kwargs):
         input_shape = ctx.get_shape(node.input_tensor_names[0])


### PR DESCRIPTION
解决下面的问题：

```python
2021-12-03 13:37:17.823896600 [E:onnxruntime:, sequential_executor.cc:346 Execute] Non-zero status code returned while running PRelu node. Name:'backbone.prelu-prelu_2' Status Message: /onnxruntime_src/onnxruntime/core/providers/cpu/math/element_wise_ops.h:497 void onnxruntime::BroadcastIterator::Init(ptrdiff_t, ptrdiff_t) axis == 1 || axis == largest was false. Attempting to broadcast an axis by a dimension other than 1. 64 by 112
```

关联：https://github.com/pytorch/pytorch/pull/21330

![图片](https://user-images.githubusercontent.com/35585791/144561084-8e8467a9-f3ea-495c-be26-946b4e96c185.png)
