### PR TITLE
numpy version deprecated  numpy.bool fix

### DIFF
--- a/oneflow_onnx/util.py
+++ b/oneflow_onnx/util.py
@@ -71,7 +71,7 @@ ONNX_2_NUMPY_DTYPE = {
     onnx_pb.TensorProto.UINT16: np.uint16,
     onnx_pb.TensorProto.INT64: np.int64,
     onnx_pb.TensorProto.UINT64: np.uint64,
-    onnx_pb.TensorProto.BOOL: np.bool,
+    onnx_pb.TensorProto.BOOL: np.bool_,
 }
 
 #


### PR DESCRIPTION
numpy deprecated bug fix since the version of numpy is > 1.23. but it deprecated since 1.20

> AttributeError: module 'numpy' has no attribute 'bool'.
> `np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
> The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
>     https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
